### PR TITLE
Cloud Concierge Report - 2023-08-22-22-12

### DIFF
--- a/terraform/networking/cloud-concierge/imports/2023-08-22-22-12_imports.tf
+++ b/terraform/networking/cloud-concierge/imports/2023-08-22-22-12_imports.tf
@@ -1,0 +1,32 @@
+import {
+  to = "aws_internet_gateway.igw-04c005e43b0b3691b"
+  id = "igw-04c005e43b0b3691b"
+}
+import {
+  to = "aws_subnet.subnet-017ae65aee75cce1b"
+  id = "subnet-017ae65aee75cce1b"
+}
+import {
+  to = "aws_subnet.subnet-01ead941fe1427f3a"
+  id = "subnet-01ead941fe1427f3a"
+}
+import {
+  to = "aws_subnet.subnet-0291d0acc48a58c1a"
+  id = "subnet-0291d0acc48a58c1a"
+}
+import {
+  to = "aws_subnet.subnet-04f8e5219f5bf736f"
+  id = "subnet-04f8e5219f5bf736f"
+}
+import {
+  to = "aws_subnet.subnet-07624cc5b8fba4220"
+  id = "subnet-07624cc5b8fba4220"
+}
+import {
+  to = "aws_subnet.subnet-0f4719c7fe46fb68a"
+  id = "subnet-0f4719c7fe46fb68a"
+}
+import {
+  to = "aws_vpc.vpc-0e09893b5558d2100"
+  id = "vpc-0e09893b5558d2100"
+}

--- a/terraform/networking/new-resources.tf
+++ b/terraform/networking/new-resources.tf
@@ -1,0 +1,105 @@
+# This resource has no identified cost 
+resource "aws_subnet" "subnet_01ead941fe1427f3a" {
+  assign_ipv6_address_on_creation                = "false"
+  cidr_block                                     = "172.31.48.0/20"
+  enable_dns64                                   = "false"
+  enable_resource_name_dns_a_record_on_launch    = "false"
+  enable_resource_name_dns_aaaa_record_on_launch = "false"
+  ipv6_native                                    = "false"
+  map_customer_owned_ip_on_launch                = "false"
+  map_public_ip_on_launch                        = "true"
+  private_dns_hostname_type_on_launch            = "ip-name"
+  vpc_id                                         = "${data.terraform_remote_state.local.outputs.aws_vpc_tfer--vpc-0e09893b5558d2100_id}"
+}
+
+# This resource has no identified cost 
+resource "aws_subnet" "subnet_0291d0acc48a58c1a" {
+  assign_ipv6_address_on_creation                = "false"
+  cidr_block                                     = "172.31.64.0/20"
+  enable_dns64                                   = "false"
+  enable_resource_name_dns_a_record_on_launch    = "false"
+  enable_resource_name_dns_aaaa_record_on_launch = "false"
+  ipv6_native                                    = "false"
+  map_customer_owned_ip_on_launch                = "false"
+  map_public_ip_on_launch                        = "true"
+  private_dns_hostname_type_on_launch            = "ip-name"
+  vpc_id                                         = "${data.terraform_remote_state.local.outputs.aws_vpc_tfer--vpc-0e09893b5558d2100_id}"
+}
+
+# This resource has no identified cost 
+resource "aws_subnet" "subnet_04f8e5219f5bf736f" {
+  assign_ipv6_address_on_creation                = "false"
+  cidr_block                                     = "172.31.16.0/20"
+  enable_dns64                                   = "false"
+  enable_resource_name_dns_a_record_on_launch    = "false"
+  enable_resource_name_dns_aaaa_record_on_launch = "false"
+  ipv6_native                                    = "false"
+  map_customer_owned_ip_on_launch                = "false"
+  map_public_ip_on_launch                        = "true"
+  private_dns_hostname_type_on_launch            = "ip-name"
+  vpc_id                                         = "${data.terraform_remote_state.local.outputs.aws_vpc_tfer--vpc-0e09893b5558d2100_id}"
+}
+
+# This resource has no identified cost 
+# Created at 2023-08-20 by root
+resource "aws_subnet" "subnet_07624cc5b8fba4220" {
+  assign_ipv6_address_on_creation                = "false"
+  cidr_block                                     = "172.31.80.0/20"
+  enable_dns64                                   = "false"
+  enable_resource_name_dns_a_record_on_launch    = "false"
+  enable_resource_name_dns_aaaa_record_on_launch = "false"
+  ipv6_native                                    = "false"
+  map_customer_owned_ip_on_launch                = "false"
+  map_public_ip_on_launch                        = "true"
+  private_dns_hostname_type_on_launch            = "ip-name"
+  vpc_id                                         = "${data.terraform_remote_state.local.outputs.aws_vpc_tfer--vpc-0e09893b5558d2100_id}"
+}
+
+# This resource has no identified cost 
+# Created at 2023-08-20 by ElasticLoadBalancing
+resource "aws_subnet" "subnet_0f4719c7fe46fb68a" {
+  assign_ipv6_address_on_creation                = "false"
+  cidr_block                                     = "172.31.0.0/20"
+  enable_dns64                                   = "false"
+  enable_resource_name_dns_a_record_on_launch    = "false"
+  enable_resource_name_dns_aaaa_record_on_launch = "false"
+  ipv6_native                                    = "false"
+  map_customer_owned_ip_on_launch                = "false"
+  map_public_ip_on_launch                        = "true"
+  private_dns_hostname_type_on_launch            = "ip-name"
+  vpc_id                                         = "${data.terraform_remote_state.local.outputs.aws_vpc_tfer--vpc-0e09893b5558d2100_id}"
+}
+
+# This resource has no identified cost 
+# Created at 2023-08-20 by ElasticLoadBalancing
+resource "aws_vpc" "vpc_0e09893b5558d2100" {
+  assign_generated_ipv6_cidr_block     = "false"
+  cidr_block                           = "172.31.0.0/16"
+  enable_classiclink                   = "false"
+  enable_classiclink_dns_support       = "false"
+  enable_dns_hostnames                 = "true"
+  enable_dns_support                   = "true"
+  enable_network_address_usage_metrics = "false"
+  instance_tenancy                     = "default"
+  ipv6_netmask_length                  = "0"
+}
+
+# This resource has no identified cost 
+resource "aws_internet_gateway" "igw_04c005e43b0b3691b" {
+  vpc_id = "${data.terraform_remote_state.local.outputs.aws_vpc_tfer--vpc-0e09893b5558d2100_id}"
+}
+
+# This resource has no identified cost 
+resource "aws_subnet" "subnet_017ae65aee75cce1b" {
+  assign_ipv6_address_on_creation                = "false"
+  cidr_block                                     = "172.31.32.0/20"
+  enable_dns64                                   = "false"
+  enable_resource_name_dns_a_record_on_launch    = "false"
+  enable_resource_name_dns_aaaa_record_on_launch = "false"
+  ipv6_native                                    = "false"
+  map_customer_owned_ip_on_launch                = "false"
+  map_public_ip_on_launch                        = "true"
+  private_dns_hostname_type_on_launch            = "ip-name"
+  vpc_id                                         = "${data.terraform_remote_state.local.outputs.aws_vpc_tfer--vpc-0e09893b5558d2100_id}"
+}
+


### PR DESCRIPTION

Cloud Concierge Report - State of Scanned Cloud Resources
=========================================================

# How to Read this Report
  
'Cloud Concierge Report' has run. Of the resources the execution scans, at least one resource was identified to have drifted or be outside of Terraform control. While code has been generated of the Terraform code and corresponding import statements needed to bring these resources under Terraform control, below you will find a summary of the gaps identified in your current IaC posture.
# Identified Security Risks
  
**Instance ID**: `arn:aws:ec2:us-east-1:380830757238:subnet/subnet-017ae65aee75cce1b`
|Rule Description|Severity|Resolution|Doc Links|
| :---: | :---: | :---: | :---: |
|Instances in a subnet should not receive a public IP address by default.|HIGH    |Set the instance to not be publicly accessible|[Rule](https://aquasecurity.github.io/tfsec/v1.28.1/checks/aws/ec2/no-public-ip-subnet/), [Tf Doc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/subnet#map_public_ip_on_launch)|
  
**Instance ID**: `arn:aws:ec2:us-east-1:380830757238:subnet/subnet-01ead941fe1427f3a`
|Rule Description|Severity|Resolution|Doc Links|
| :---: | :---: | :---: | :---: |
|Instances in a subnet should not receive a public IP address by default.|HIGH    |Set the instance to not be publicly accessible|[Rule](https://aquasecurity.github.io/tfsec/v1.28.1/checks/aws/ec2/no-public-ip-subnet/), [Tf Doc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/subnet#map_public_ip_on_launch)|
  
**Instance ID**: `arn:aws:ec2:us-east-1:380830757238:subnet/subnet-0291d0acc48a58c1a`
|Rule Description|Severity|Resolution|Doc Links|
| :---: | :---: | :---: | :---: |
|Instances in a subnet should not receive a public IP address by default.|HIGH    |Set the instance to not be publicly accessible|[Rule](https://aquasecurity.github.io/tfsec/v1.28.1/checks/aws/ec2/no-public-ip-subnet/), [Tf Doc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/subnet#map_public_ip_on_launch)|
  
**Instance ID**: `arn:aws:ec2:us-east-1:380830757238:subnet/subnet-04f8e5219f5bf736f`
|Rule Description|Severity|Resolution|Doc Links|
| :---: | :---: | :---: | :---: |
|Instances in a subnet should not receive a public IP address by default.|HIGH    |Set the instance to not be publicly accessible|[Rule](https://aquasecurity.github.io/tfsec/v1.28.1/checks/aws/ec2/no-public-ip-subnet/), [Tf Doc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/subnet#map_public_ip_on_launch)|
  
**Instance ID**: `arn:aws:ec2:us-east-1:380830757238:subnet/subnet-07624cc5b8fba4220`
|Rule Description|Severity|Resolution|Doc Links|
| :---: | :---: | :---: | :---: |
|Instances in a subnet should not receive a public IP address by default.|HIGH    |Set the instance to not be publicly accessible|[Rule](https://aquasecurity.github.io/tfsec/v1.28.1/checks/aws/ec2/no-public-ip-subnet/), [Tf Doc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/subnet#map_public_ip_on_launch)|
  
**Instance ID**: `arn:aws:ec2:us-east-1:380830757238:subnet/subnet-0a5beded7937f0ddd`
|Rule Description|Severity|Resolution|Doc Links|
| :---: | :---: | :---: | :---: |
|Instances in a subnet should not receive a public IP address by default.|HIGH    |Set the instance to not be publicly accessible|[Rule](https://aquasecurity.github.io/tfsec/v1.28.1/checks/aws/ec2/no-public-ip-subnet/), [Tf Doc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/subnet#map_public_ip_on_launch)|
  
**Instance ID**: `arn:aws:ec2:us-east-1:380830757238:subnet/subnet-0f4719c7fe46fb68a`
|Rule Description|Severity|Resolution|Doc Links|
| :---: | :---: | :---: | :---: |
|Instances in a subnet should not receive a public IP address by default.|HIGH    |Set the instance to not be publicly accessible|[Rule](https://aquasecurity.github.io/tfsec/v1.28.1/checks/aws/ec2/no-public-ip-subnet/), [Tf Doc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/subnet#map_public_ip_on_launch)|
  
**Instance ID**: `arn:aws:ec2:us-east-1:380830757238:vpc/vpc-0a2ed9072eb2fdad1`
|Rule Description|Severity|Resolution|Doc Links|
| :---: | :---: | :---: | :---: |
|VPC Flow Logs is a feature that enables you to capture information about the IP traffic going to and from network interfaces in your VPC. After you've created a flow log, you can view and retrieve its data in Amazon CloudWatch Logs. It is recommended that VPC Flow Logs be enabled for packet "Rejects" for VPCs.|MEDIUM  |Enable flow logs for VPC|[Rule](https://aquasecurity.github.io/tfsec/v1.28.1/checks/aws/ec2/require-vpc-flow-logs-for-all-vpcs/)|
  
**Instance ID**: `arn:aws:ec2:us-east-1:380830757238:vpc/vpc-0e09893b5558d2100`
|Rule Description|Severity|Resolution|Doc Links|
| :---: | :---: | :---: | :---: |
|VPC Flow Logs is a feature that enables you to capture information about the IP traffic going to and from network interfaces in your VPC. After you've created a flow log, you can view and retrieve its data in Amazon CloudWatch Logs. It is recommended that VPC Flow Logs be enabled for packet "Rejects" for VPCs.|MEDIUM  |Enable flow logs for VPC|[Rule](https://aquasecurity.github.io/tfsec/v1.28.1/checks/aws/ec2/require-vpc-flow-logs-for-all-vpcs/)|

# Calculable Cloud Costs (Monthly)
  
Cost estimation not run.
# Resources Outside of Terraform Control
  
No new resources found!
# Drifted Resources Managed By Terraform
  
No controlled resources have drifted!
# Root Causes of Drift

## Cloud Actors Causing Changes

|Actor|Action|Count|
| :---: | :---: | :---: |
|ElasticLoadBalancing|Create Resource|2|
|root|Create Resource|1|

#### Disclaimer
  
*Indicates that a resource's cost is usage based. Since we currently do not infer/have knowledge of usage, costs may be material although indicated as 0 here.  
  
This report presents information on the state of your cloud at a point in time and as best Cloud Concierge is able to determine. Cloud Concierge does not currently scan every cloud resource for every  cloud provider. For a list of supported resources, please see our [documentation](https://www.docs.dragondrop.cloud/).  
  
Created by Cloud Concierge at 22:12 UTC on 2023-08-22